### PR TITLE
Fixed jpegSignature for streamCamera.takeImage to work

### DIFF
--- a/src/lib/stream-camera.ts
+++ b/src/lib/stream-camera.ts
@@ -37,7 +37,7 @@ declare interface StreamCamera {
 
 class StreamCamera extends EventEmitter {
 
-	static readonly jpegSignature = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00]);
+	static readonly jpegSignature = Buffer.from([0xFF, 0xD8, 0xFF, 0xDB, 0x00, 0x84, 0x00]);
 
 	private options: StreamOptions;
 	private childProcess?: ChildProcess;


### PR DESCRIPTION
I've tried your solution and it didn't work for me to take pictures with streamCamera. I found the data set repeats more often than the frames come in. The signature I added works for me, but this needs additional testing to confirm.
Also, this refers to the one open issue here, so, if it's confirmed, the issue can be closed, too.